### PR TITLE
Add license to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include wsaccel/*.[ch]
 include README.rst
+include LICENSE


### PR DESCRIPTION
This patch adds the `LICENSE` file to the `MANIFEST.in` so that it is included during packaging/distribution.