### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 arch:
  - amd64
  - ppc64le
+ - arm64-graviton2
 sudo: false
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+ - amd64
+ - ppc64le
 sudo: false
 language: python
 python:


### PR DESCRIPTION
Adding Power support.
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/wsaccel

Please let me know if you need any further details.

Thank You !!