### PR TITLE
Set license to a valid SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "Cython~=3.0.11",
-    "setuptools>=35.0.2",
+    "setuptools>=77.0.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -14,7 +14,7 @@ readme = "README.rst"
 authors = [
   {name = "Inada Naoki", email="songofacandy@gmail.com"},
 ]
-license = {text = "Apache 2.0"}
+license = "Apache-2.0"
 
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
Setting the license field to a table is deprecated since setuptools 77.0.0 and will no longer be supported on 18 February 2026.

---

For more information see [the python packaging guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license). 

And my local build's output:

```
writing manifest file 'wsaccel.egg-info/SOURCES.txt'
* Building wheel...
/usr/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum build-system tooling requirement to a newer setuptools version to align with modern packaging standards.
  * Standardized the project license declaration to the SPDX identifier "Apache-2.0," improving metadata consistency and compatibility with packaging tools and registries.

* **Documentation**
  * Clarified license information in project metadata for clearer identification by users and automated tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->