### PR TITLE
pyproject: allow building against Cython 3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython~=3.0.11",
+    "Cython<=3.2",
     "setuptools>=77.0.2",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Arch Linux already builds against Cython 3.1.6 with v0.6.6, but in v0.6.7 the Cython version checked was restricted to 3.0.x while it compiles and the tests pass against 3.1.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependency version constraints to support newer compatible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->